### PR TITLE
catch missing np.abs()

### DIFF
--- a/mean-slopes/Correlation.Rmd
+++ b/mean-slopes/Correlation.Rmd
@@ -487,7 +487,7 @@ correlation coefficients that were as extreme or more extreme than the actual co
 to the actual correlation coefficient, ignoring the direction (+ or -) of the coefficients.
 
 ```{python}
-p_value = np.count_nonzero(results >= np.abs(r))/n_iters
+p_value = np.count_nonzero(np.abs(results) >= np.abs(r))/n_iters
 
 p_value
 ```

--- a/mean-slopes/Correlation.Rmd
+++ b/mean-slopes/Correlation.Rmd
@@ -398,7 +398,7 @@ misused. Before using $r$, it is important to be aware of what
 correlation does and does not measure.
 
 
-### A Permutation Test for the Correlation Coefficient
+## A Permutation Test for the Correlation Coefficient ##
 
 We can perform a permutation test for the correlation coefficient in a very similar manner to the 
 permutation tests we have seen previously.


### PR DESCRIPTION
missed np.abs() from the permuted statistics in the p-value calculation...